### PR TITLE
Drop skydns replicas to 1

### DIFF
--- a/skydns/skydns.yaml
+++ b/skydns/skydns.yaml
@@ -14,7 +14,7 @@ metadata:
   name: kube-dns-v3
   namespace: kube-system
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     k8s-app: kube-dns
     version: v9


### PR DESCRIPTION
The kubernetes conformance tests are gating on the presence of _exactly_
1 pod that matches a known label selector.  Longer term, I think these
tests are way too white-box to be considered conformance tests.  For
now, let's just match what's being looked for